### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft tests


### PR DESCRIPTION
This makes it easier for downstream packagers to verify their installation.